### PR TITLE
Updates gitignore for usage with pycharm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.pyc
+venv
+.idea


### PR DESCRIPTION
This is so that we can use intelliJ:s pycharm as IDE