### PR TITLE
Ensuring the signature is at the end part of the query string

### DIFF
--- a/binance_f/impl/utils/urlparamsbuilder.py
+++ b/binance_f/impl/utils/urlparamsbuilder.py
@@ -26,7 +26,17 @@ class UrlParamsBuilder(object):
     def build_url(self):
         if len(self.param_map) == 0:
             return ""
+        # Error -1022: Signature for this request is not valid.
+        # => Ensure 'signature' parameter is at the end of the URL, as per doc.
+        signature = ''
+        if 'signature' in self.param_map:
+            # Remove it from the (unsorted) dic and append manually
+            signature = self.param_map['signature']
+            del self.param_map['signature']
+            signature = "&signature=%s" % signature
         encoded_param = urllib.parse.urlencode(self.param_map)
+        # Append the signature manually. URL encoding is not necessary here.
+        encoded_param += signature
         return encoded_param
 
     def build_url_to_json(self):


### PR DESCRIPTION
As per documentation, the signature must be the very end of the URL 

> Please make sure the signature is the end part of your query string or request body.

Source: https://binanceapitest.github.io/Binance-Future-API-test-doc/trade_and_account/#signed-trade-and-user_data-endpoint-security

This change helped me to fix the `Error -1022: Signature for this request is not valid` error, which occurred each time the signature was not at the end. 

Hint for build_url(): Unlike list(), dict() do not preserve the order of the elements added. 
