### PR TITLE
updated get_position_v2 for symbol request

### DIFF
--- a/binance_f/impl/restapirequestimpl.py
+++ b/binance_f/impl/restapirequestimpl.py
@@ -918,8 +918,9 @@ class RestApiRequestImpl(object):
         request.json_parser = parse
         return request
 
-    def get_position_v2(self):
+    def get_position_v2(self, symbol):
         builder = UrlParamsBuilder()
+        builder.put_url("symbol", symbol)
 
         request = self.__create_request_by_get_with_signature("/fapi/v2/positionRisk", builder)
 

--- a/binance_f/impl/restapirequestimpl.py
+++ b/binance_f/impl/restapirequestimpl.py
@@ -204,6 +204,30 @@ class RestApiRequestImpl(object):
 
         request.json_parser = parse
         return request
+
+    def get_spot_candlestick_data(self, symbol, interval, startTime, endTime, limit):
+        check_should_not_none(symbol, "symbol")
+        check_should_not_none(symbol, "interval")
+        builder = UrlParamsBuilder()
+        builder.put_url("symbol", symbol)
+        builder.put_url("interval", interval)
+        builder.put_url("startTime", startTime)
+        builder.put_url("endTime", endTime)
+        builder.put_url("limit", limit)
+
+        request = self.__create_request_by_get("/api/v3/klines", builder)
+        request.host = 'https://api.binance.com'
+
+        def parse(json_wrapper):
+            result = list()
+            data_list = json_wrapper.convert_2_array()
+            for item in data_list.get_items():
+                element = Candlestick.json_parse(item)
+                result.append(element)
+            return result
+
+        request.json_parser = parse
+        return request
           
     def get_candlestick_data(self, symbol, interval, startTime, endTime, limit):
         check_should_not_none(symbol, "symbol")

--- a/binance_f/impl/websocketconnection.py
+++ b/binance_f/impl/websocketconnection.py
@@ -76,12 +76,16 @@ class WebsocketConnection:
         self.__watch_dog = watch_dog
         self.delay_in_second = -1
         self.ws = None
+        self.receive_limit_ms = self.__watch_dog.receive_limit_ms
         self.last_receive_time = 0
         self.logger = logging.getLogger("binance-futures")
         self.state = ConnectionState.IDLE
         global connection_id
         connection_id += 1
         self.id = connection_id
+
+    def set_receive_limit_ms(self, receive_limit_ms):
+        self.last_receive_time = receive_limit_ms
 
     def in_delay_connection(self):
         return self.delay_in_second != -1

--- a/binance_f/impl/websocketconnection.py
+++ b/binance_f/impl/websocketconnection.py
@@ -85,7 +85,7 @@ class WebsocketConnection:
         self.id = connection_id
 
     def set_receive_limit_ms(self, receive_limit_ms):
-        self.last_receive_time = receive_limit_ms
+        self.receive_limit_ms = receive_limit_ms
 
     def in_delay_connection(self):
         return self.delay_in_second != -1

--- a/binance_f/impl/websocketwatchdog.py
+++ b/binance_f/impl/websocketwatchdog.py
@@ -11,7 +11,7 @@ def watch_dog_job(*args):
         if connection.state == ConnectionState.CONNECTED:
             if watch_dog_instance.is_auto_connect:
                 ts = get_current_timestamp() - connection.last_receive_time
-                if ts > watch_dog_instance.receive_limit_ms:
+                if ts > connection.receive_limit_ms:
                     watch_dog_instance.logger.warning("[Sub][" + str(connection.id) + "] No response from server")
                     connection.re_connect_in_delay(watch_dog_instance.connection_delay_failure)
         elif connection.in_delay_connection():

--- a/binance_f/requestclient.py
+++ b/binance_f/requestclient.py
@@ -106,6 +106,15 @@ class RequestClient(object):
         response = call_sync(self.request_impl.get_aggregate_trades_list(symbol, fromId, startTime, endTime, limit))
         self.refresh_limits(response[1])
         return response[0]
+
+    def get_spot_candlestick_data(self, symbol: 'str', interval: 'CandlestickInterval',
+                                  startTime: 'long' = None, endTime: 'long' = None, limit: 'int' = None) -> any:
+        """
+        GET /api/v3/klines
+        """
+        response = call_sync(self.request_impl.get_spot_candlestick_data(symbol, interval, startTime, endTime, limit))
+        self.refresh_limits(response[1])
+        return response[0]
               
     def get_candlestick_data(self, symbol: 'str', interval: 'CandlestickInterval', 
                             startTime: 'long' = None, endTime: 'long' = None, limit: 'int' = None) -> any:

--- a/binance_f/requestclient.py
+++ b/binance_f/requestclient.py
@@ -566,13 +566,13 @@ class RequestClient(object):
         self.refresh_limits(response[1])
         return response[0]
 
-    def get_position_v2(self) -> any:
+    def get_position_v2(self, symbol: 'str' = None) -> any:
         """
         Position Information (USER_DATA)
 
         GET /fapi/v2/positionRisk (HMAC SHA256) Get current account information.
         """
-        response = call_sync(self.request_impl.get_position_v2())
+        response = call_sync(self.request_impl.get_position_v2(symbol))
         self.refresh_limits(response[1])
         return response[0]
 

--- a/binance_f/subscriptionclient.py
+++ b/binance_f/subscriptionclient.py
@@ -85,6 +85,17 @@ class SubscriptionClient(object):
         """
         request = self.websocket_request_impl.subscribe_mark_price_event(symbol, callback, error_handler)
         self.__create_connection(request)
+
+    def subscribe_spot_candlestick_event(self, symbol: 'str', interval: 'CandlestickInterval', callback,
+                                    error_handler=None):
+        """
+            Stream Name: <symbol>@kline_<interval>
+        """
+        request = self.websocket_request_impl.subscribe_candlestick_event(symbol, interval, callback, error_handler)
+        futures_uri = self.uri
+        self.uri = 'wss://stream.binance.com:9443/ws'
+        self.__create_connection(request)
+        self.uri = futures_uri
     
     def subscribe_candlestick_event(self, symbol: 'str', interval: 'CandlestickInterval', callback,
                                     error_handler=None):


### PR DESCRIPTION
After the binance logs...

> "New endpoint GET /fapi/v2/positionRisk in version 2 of fapi:
> 
>     User can choose to send specific "symbol".
>     All symbols in the market can be returned.
>     Different responses for "One-way" or "Hedge" position mode.
>     Better performance than the v1 endpoint."


... you can also send a symbol alone for getting the position. I adjusted this.

best regards
Felix
