### PR TITLE
fix get_position_mode function

### DIFF
--- a/binance_f/impl/restapirequestimpl.py
+++ b/binance_f/impl/restapirequestimpl.py
@@ -382,7 +382,7 @@ class RestApiRequestImpl(object):
 
 
     def get_position_mode(self):
-        
+        builder = UrlParamsBuilder()
         request = self.__create_request_by_get_with_signature("/fapi/v1/positionSide/dual", builder)
 
         def parse(json_wrapper):


### PR DESCRIPTION
get_position_mode function can't work, I add a declare "builder = UrlParamsBuilder()".

TraceBack Infomation:
NameError                                 Traceback (most recent call last)
<ipython-input-12-1eb9d5af4a44> in <module>
      1 # 获取持仓模式
      2 # result = request_client.get_position_v2()
----> 3 request_client.get_position_mode()

c:\users\rainlfow\appdata\local\programs\python\python36\lib\site-packages\binance_futures-1.1.0-py3.6.egg\binance_f\requestclient.py in get_position_mode(self)
    225         Get user's position mode (Hedge Mode or One-way Mode ) on EVERY symbol
    226         """
--> 227         response = call_sync(self.request_impl.get_position_mode())
    228         self.refresh_limits(response[1])
    229         return response[0]

c:\users\rainlfow\appdata\local\programs\python\python36\lib\site-packages\binance_futures-1.1.0-py3.6.egg\binance_f\impl\restapirequestimpl.py in get_position_mode(self)
    384     def get_position_mode(self):
    385 
--> 386         request = self.__create_request_by_get_with_signature("/fapi/v1/positionSide/dual", builder)
    387 
    388         def parse(json_wrapper):

NameError: name 'builder' is not defined